### PR TITLE
SMS API 연결 및 프로필에 따른 테스트 웹훅 설정

### DIFF
--- a/danuri-rest/build.gradle.kts
+++ b/danuri-rest/build.gradle.kts
@@ -11,15 +11,23 @@ dependencies {
     implementation("org.springframework.security:spring-security-crypto")
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework:spring-tx")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("io.jsonwebtoken:jjwt-api:0.12.6")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
     implementation("com.bucket4j:bucket4j-core:8.10.1")
+    implementation("net.nurigo:sdk:4.2.7")
     implementation("org.apache.poi:poi:5.4.1")
     implementation("org.apache.poi:poi-ooxml:5.4.1")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
+}
+
+allOpen {
+    annotation("jakarta.persistence.Entity")
+    annotation("jakarta.persistence.MappedSuperclass")
+    annotation("jakarta.persistence.Embeddable")
 }
 
 tasks.getByName("jar") {

--- a/danuri-rest/build.gradle.kts
+++ b/danuri-rest/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     kotlin("plugin.spring") version "1.9.25"
-    id("org.springframework.boot") version "3.4.4"
+    id("org.springframework.boot") version "3.5.0"
     id("io.sentry.jvm.gradle") version "5.5.0"
     id("io.spring.dependency-management") version "1.1.7"
 }
@@ -16,6 +16,7 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:0.12.6")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
     implementation("com.bucket4j:bucket4j-core:8.10.1")
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign:4.3.0")
     implementation("net.nurigo:sdk:4.2.7")
     implementation("org.apache.poi:poi:5.4.1")
     implementation("org.apache.poi:poi-ooxml:5.4.1")

--- a/danuri-rest/src/main/kotlin/org/aing/danurirest/DanuriRestApplication.kt
+++ b/danuri-rest/src/main/kotlin/org/aing/danurirest/DanuriRestApplication.kt
@@ -2,9 +2,11 @@ package org.aing.danurirest
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.cloud.openfeign.EnableFeignClients
 import java.util.TimeZone
 
 @SpringBootApplication(scanBasePackages = ["org.aing.danuridomain", "org.aing.danurirest"])
+@EnableFeignClients
 class DanuriRestApplication
 
 fun main(args: Array<String>) {

--- a/danuri-rest/src/main/kotlin/org/aing/danurirest/domain/auth/user/usecase/SendUserAuthCodeUsecase.kt
+++ b/danuri-rest/src/main/kotlin/org/aing/danurirest/domain/auth/user/usecase/SendUserAuthCodeUsecase.kt
@@ -1,15 +1,20 @@
 package org.aing.danurirest.domain.auth.user.usecase
 
+import net.nurigo.sdk.NurigoApp
+import net.nurigo.sdk.message.exception.NurigoMessageNotReceivedException
+import net.nurigo.sdk.message.model.Message
 import org.aing.danuridomain.persistence.user.entity.UserAuthCode
 import org.aing.danuridomain.persistence.user.repository.UserAuthCodeRepository
 import org.aing.danuridomain.persistence.user.repository.UserRepository
 import org.aing.danurirest.global.exception.CustomException
 import org.aing.danurirest.global.exception.enums.CustomErrorCode
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 import java.util.Random
 
 @Service
+@Transactional(rollbackFor = [Exception::class])
 class SendUserAuthCodeUsecase(
     private val userRepository: UserRepository,
     private val userAuthCodeRepository: UserAuthCodeRepository,
@@ -18,7 +23,7 @@ class SendUserAuthCodeUsecase(
         private const val AUTH_CODE_EXPIRE_MINUTES = 5L
     }
 
-    fun execute(phone: String): String {
+    fun execute(phone: String) {
         if (!userRepository.existsByPhone(phone)) {
             throw CustomException(CustomErrorCode.NOT_FOUND_USER)
         }
@@ -35,9 +40,13 @@ class SendUserAuthCodeUsecase(
                 expiredAt = expiredAt,
             )
         userAuthCodeRepository.save(userAuthCode)
-
-        // TODO: 뿌리오 연결
-        return authCode
+        val message = Message(from = "", to = phone, text = "[송정다누리센터] 인증번호는 $authCode 입니다. 본인이 아닐 경우, 문의 해주세요.")
+        try {
+            val messageService = NurigoApp.initialize(apiKey = "", apiSecretKey = "", domain = "https://api.solapi.com")
+            messageService.send(message)
+        } catch (e: NurigoMessageNotReceivedException) {
+            throw CustomException(CustomErrorCode.UNKNOWN_SERVER_ERROR)
+        }
     }
 
     private fun generateRandomCode(): String {

--- a/danuri-rest/src/main/kotlin/org/aing/danurirest/domain/auth/user/usecase/SendUserAuthCodeUsecase.kt
+++ b/danuri-rest/src/main/kotlin/org/aing/danurirest/domain/auth/user/usecase/SendUserAuthCodeUsecase.kt
@@ -16,11 +16,11 @@ import java.util.Random
 @Service
 @Transactional(rollbackFor = [Exception::class])
 class SendUserAuthCodeUsecase(
-    @Value("\${solapi.key}")
+    @Value("\${sms.apiKey}")
     private val solApiKey: String,
-    @Value("\${solapi.secret}")
+    @Value("\${sms.apiSecret}")
     private val solApiSecretKey: String,
-    @Value("\${solapi.from}")
+    @Value("\${sms.fromnumber}")
     private val solfrom: String,
     private val userRepository: UserRepository,
     private val userAuthCodeRepository: UserAuthCodeRepository,

--- a/danuri-rest/src/main/kotlin/org/aing/danurirest/domain/auth/user/usecase/SendUserAuthCodeUsecase.kt
+++ b/danuri-rest/src/main/kotlin/org/aing/danurirest/domain/auth/user/usecase/SendUserAuthCodeUsecase.kt
@@ -46,7 +46,7 @@ class SendUserAuthCodeUsecase(
                 expiredAt = expiredAt,
             )
         userAuthCodeRepository.save(userAuthCode)
-        val message = Message(from = solfrom, to = phone.replace("-", ""), text = "[송정다누리청소년문화의집] 인증번호는 $authCode 입니다. 본인이 아닐 경우, 문의 해주세요.")
+        val message = Message(from = solfrom, to = phone.replace("-", ""), text = "[송정다누리청소년문화의집] 본인확인을 위해 인증번호 [$authCode]를 입력해 주세요.")
         try {
             val messageService =
                 NurigoApp.initialize(

--- a/danuri-rest/src/main/kotlin/org/aing/danurirest/global/third_party/discord/client/DiscordFeignClient.kt
+++ b/danuri-rest/src/main/kotlin/org/aing/danurirest/global/third_party/discord/client/DiscordFeignClient.kt
@@ -1,0 +1,15 @@
+package org.aing.danurirest.global.third_party.discord.client
+
+import org.aing.danurirest.global.third_party.discord.dto.DiscordMessage
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+
+@FeignClient(name = "\${discord.name}", url = "\${discord.webhook-url}")
+interface DiscordFeignClient {
+    @PostMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun sendMessage(
+        @RequestBody discordMessage: DiscordMessage?,
+    )
+}

--- a/danuri-rest/src/main/kotlin/org/aing/danurirest/global/third_party/discord/dto/DiscordMessage.kt
+++ b/danuri-rest/src/main/kotlin/org/aing/danurirest/global/third_party/discord/dto/DiscordMessage.kt
@@ -1,0 +1,5 @@
+package org.aing.danurirest.global.third_party.discord.dto
+
+data class DiscordMessage(
+    val content: String,
+)

--- a/danuri-rest/src/main/kotlin/org/aing/danurirest/global/third_party/sms/SendSmsUsecase.kt
+++ b/danuri-rest/src/main/kotlin/org/aing/danurirest/global/third_party/sms/SendSmsUsecase.kt
@@ -16,6 +16,13 @@ class SendSmsUsecase(
     @Value("\${sms.fromnumber}")
     private val solfrom: String,
 ) {
+    private val messageService =
+        NurigoApp.initialize(
+            apiKey = solApiKey,
+            apiSecretKey = solApiSecretKey,
+            domain = "https://api.solapi.com",
+        )
+
     fun execute(
         phone: String,
         text: String,
@@ -28,12 +35,6 @@ class SendSmsUsecase(
             )
 
         try {
-            val messageService =
-                NurigoApp.initialize(
-                    apiKey = solApiKey,
-                    apiSecretKey = solApiSecretKey,
-                    domain = "https://api.solapi.com",
-                )
             messageService.send(message)
         } catch (e: Exception) {
             throw CustomException(CustomErrorCode.UNKNOWN_SERVER_ERROR)

--- a/danuri-rest/src/main/kotlin/org/aing/danurirest/global/third_party/sms/SendSmsUsecase.kt
+++ b/danuri-rest/src/main/kotlin/org/aing/danurirest/global/third_party/sms/SendSmsUsecase.kt
@@ -1,0 +1,42 @@
+package org.aing.danurirest.global.third_party.sms
+
+import net.nurigo.sdk.NurigoApp
+import net.nurigo.sdk.message.model.Message
+import org.aing.danurirest.global.exception.CustomException
+import org.aing.danurirest.global.exception.enums.CustomErrorCode
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+
+@Service
+class SendSmsUsecase(
+    @Value("\${sms.apiKey}")
+    private val solApiKey: String,
+    @Value("\${sms.apiSecret}")
+    private val solApiSecretKey: String,
+    @Value("\${sms.fromnumber}")
+    private val solfrom: String,
+) {
+    fun execute(
+        phone: String,
+        text: String,
+    ) {
+        val message =
+            Message(
+                from = solfrom,
+                to = phone.replace("-", ""),
+                text = text,
+            )
+
+        try {
+            val messageService =
+                NurigoApp.initialize(
+                    apiKey = solApiKey,
+                    apiSecretKey = solApiSecretKey,
+                    domain = "https://api.solapi.com",
+                )
+            messageService.send(message)
+        } catch (e: Exception) {
+            throw CustomException(CustomErrorCode.UNKNOWN_SERVER_ERROR)
+        }
+    }
+}

--- a/danuri-rest/src/main/resources/application.yaml
+++ b/danuri-rest/src/main/resources/application.yaml
@@ -41,6 +41,11 @@ sentry:
   send-default-pii: true
   traces-sample-rate: 1.0
 
+solapi:
+  key: ${SOLAPI_KEY}
+  secret: ${SOLAPI_SECRET_KEY}
+  from: ${SOLAPI_FROM}
+
 ---
 spring:
   config:

--- a/danuri-rest/src/main/resources/application.yaml
+++ b/danuri-rest/src/main/resources/application.yaml
@@ -41,6 +41,10 @@ sentry:
   send-default-pii: true
   traces-sample-rate: 1.0
 
+discord:
+  name: discord-feign-client
+  webhook-url: ${DISCORD_WEBHOOK}
+
 sms:
   apiKey: ${SMS_API_KEY}
   apiSecret: ${SMS_SECRET_KEY}

--- a/danuri-rest/src/main/resources/application.yaml
+++ b/danuri-rest/src/main/resources/application.yaml
@@ -41,10 +41,10 @@ sentry:
   send-default-pii: true
   traces-sample-rate: 1.0
 
-solapi:
-  key: ${SOLAPI_KEY}
-  secret: ${SOLAPI_SECRET_KEY}
-  from: ${SOLAPI_FROM}
+sms:
+  apiKey: ${SMS_API_KEY}
+  apiSecret: ${SMS_SECRET_KEY}
+  fromnumber: ${SMS_FROM_NUMBER}
 
 ---
 spring:


### PR DESCRIPTION
## 💡 배경 및 개요

Resolves: #19 , #29 

## 📃 작업내용

- 문자인증 연결
- 프로필에 따라 문자 혹은 디스코드 웹훅을 통해 인증번호 전달

## 🙋‍♂️ 리뷰노트


## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 인증 코드 발송 시, 운영 환경에 따라 Discord 또는 SMS로 인증 코드를 전송하는 기능이 추가되었습니다.
    - Discord Webhook 및 SMS(Solapi) 연동이 도입되어, 인증 메시지를 다양한 채널로 보낼 수 있습니다.
- **설정**
    - Discord 및 SMS 서비스 연동을 위한 환경 변수 및 설정 항목이 추가되었습니다.
- **기타**
    - 일부 내부 동작이 개선되어 인증 코드 관리와 메시지 전송의 신뢰성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->