### PR TITLE
[DANURI-35] 매일 하루 지난 종료된 이용 QR 제거

### DIFF
--- a/src/main/kotlin/org/aing/danurirest/DanuriRestApplication.kt
+++ b/src/main/kotlin/org/aing/danurirest/DanuriRestApplication.kt
@@ -3,9 +3,11 @@ package org.aing.danurirest
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.cloud.openfeign.EnableFeignClients
+import org.springframework.scheduling.annotation.EnableScheduling
 import java.util.TimeZone
 
 @EnableFeignClients
+@EnableScheduling
 @SpringBootApplication
 class DanuriRestApplication
 

--- a/src/main/kotlin/org/aing/danurirest/domain/storage/scheduler/DeleteQrImageScheduler.kt
+++ b/src/main/kotlin/org/aing/danurirest/domain/storage/scheduler/DeleteQrImageScheduler.kt
@@ -1,0 +1,22 @@
+package org.aing.danurirest.domain.storage.scheduler
+
+import org.aing.danurirest.global.third_party.s3.BucketType
+import org.aing.danurirest.global.third_party.s3.service.S3Service
+import org.aing.danurirest.persistence.usage.repository.UsageHistoryJpaRepository
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class DeleteQrImageScheduler(
+    private val usageHistoryJpaRepository: UsageHistoryJpaRepository,
+    private val s3Service: S3Service,
+) {
+    @Scheduled(cron = "0 0 0 * * *")
+    fun execute() {
+        val usageList = usageHistoryJpaRepository.findIdsByEndAtBetween()
+        s3Service.deleteFiles(
+            BucketType.QR_LINK,
+            usageList,
+        )
+    }
+}

--- a/src/main/kotlin/org/aing/danurirest/persistence/usage/repository/UsageHistoryJpaRepository.kt
+++ b/src/main/kotlin/org/aing/danurirest/persistence/usage/repository/UsageHistoryJpaRepository.kt
@@ -46,4 +46,10 @@ interface UsageHistoryJpaRepository : JpaRepository<UsageHistory, UUID> {
     ): List<UsageHistory>
 
     fun findByUserId(userId: UUID): Optional<UsageHistory>
+
+    @Query("SELECT CAST(u.id AS string) FROM UsageHistory u WHERE u.endAt BETWEEN :startTime AND :endTime")
+    fun findIdsByEndAtBetween(
+        @Param("startTime") startTime: LocalDateTime = LocalDateTime.now().minusDays(1),
+        @Param("endTime") endTime: LocalDateTime = LocalDateTime.now(),
+    ): List<String>
 }


### PR DESCRIPTION
## 💡 배경 및 개요

매일 하루 지난 종료된 이용 QR 제거를 통해 버킷 최적화를 진행합니다.

## 📃 작업내용

- 스케줄러 / 쿼리를 통해 매일 하루 지난 종료된 이용 QR을 버킷으로부터 제거합니다.

## 🙋‍♂️ 리뷰노트



## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 매일 자정 만료된 QR 이미지를 자동 정리하는 스케줄러가 도입되었습니다. 불필요한 링크/이미지 노출이 줄어들고 최신 상태가 유지됩니다.
* 작업
  * 애플리케이션 스케줄링을 활성화했습니다.
  * 스토리지의 파일 대량 삭제 처리를 추가해 정리 작업 효율을 높였습니다.
  * 만료 기간 기반 식별자 조회를 도입하여 정리 대상을 정확히 선별합니다.
  * 전체적으로 안정성과 비용 효율성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->