### PR TITLE
[DANURI-37] 예외 처리 개선

### DIFF
--- a/src/main/kotlin/org/aing/danurirest/global/exception/enums/CustomErrorCode.kt
+++ b/src/main/kotlin/org/aing/danurirest/global/exception/enums/CustomErrorCode.kt
@@ -10,11 +10,13 @@ enum class CustomErrorCode(
     UNKNOWN_SERVER_ERROR(HttpStatus.BAD_GATEWAY, "알 수 없는 문제가 발생했습니다."),
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "찾을 수 없습니다."),
+    ENDPOINT_NOT_FOUND(HttpStatus.NOT_FOUND, "엔드포인트를 찾을 수 없습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
     PARAMETER_ERROR(HttpStatus.BAD_REQUEST, "잘못된 파라미터입니다."),
     MISSING_REQUEST_BODY(HttpStatus.BAD_REQUEST, "요청 바디가 누락되었습니다."),
 
     // Auth
+    MISSING_TOKEN(HttpStatus.UNAUTHORIZED, "인증 토큰이 필요합니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh Token입니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 Refresh Token입니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),

--- a/src/main/kotlin/org/aing/danurirest/global/exception/handler/ExceptionHandler.kt
+++ b/src/main/kotlin/org/aing/danurirest/global/exception/handler/ExceptionHandler.kt
@@ -10,6 +10,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.HandlerMethodValidationException
+import org.springframework.web.servlet.NoHandlerFoundException
 import java.lang.RuntimeException
 
 @Slf4j
@@ -47,6 +48,16 @@ class ExceptionHandler {
             CustomExceptionResponse(
                 CustomErrorCode.MISSING_REQUEST_BODY,
                 CustomErrorCode.MISSING_REQUEST_BODY.message,
+            )
+        return ResponseEntity.status(response.status.status).body(response)
+    }
+
+    @ExceptionHandler(NoHandlerFoundException::class)
+    fun handleNoHandlerFoundException(exception: NoHandlerFoundException): ResponseEntity<CustomExceptionResponse> {
+        val response =
+            CustomExceptionResponse(
+                CustomErrorCode.ENDPOINT_NOT_FOUND,
+                CustomErrorCode.ENDPOINT_NOT_FOUND.message,
             )
         return ResponseEntity.status(response.status.status).body(response)
     }

--- a/src/main/kotlin/org/aing/danurirest/global/security/configuration/SecurityConfiguration.kt
+++ b/src/main/kotlin/org/aing/danurirest/global/security/configuration/SecurityConfiguration.kt
@@ -3,6 +3,7 @@
 package org.aing.danurirest.global.security.configuration
 
 import org.aing.danurirest.global.security.filter.JwtFilter
+import org.aing.danurirest.global.security.handler.CustomAuthenticationEntryPoint
 import org.aing.danurirest.global.security.jwt.JwtProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -18,6 +19,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 @Configuration
 class SecurityConfiguration(
     private val jwtProvider: JwtProvider,
+    private val customAuthenticationEntryPoint: CustomAuthenticationEntryPoint,
 ) {
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain =
@@ -29,26 +31,35 @@ class SecurityConfiguration(
             }.sessionManagement {
                 it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             }.addFilterBefore(JwtFilter(jwtProvider), UsernamePasswordAuthenticationFilter::class.java)
-            .authorizeHttpRequests {
+            .exceptionHandling {
+                it.authenticationEntryPoint(customAuthenticationEntryPoint)
+            }.authorizeHttpRequests {
                 // 인증/인가
                 it.requestMatchers(HttpMethod.POST, "/auth/admin/**").permitAll()
                 it.requestMatchers(HttpMethod.GET, "/auth/common/refresh").permitAll()
-                it.requestMatchers(HttpMethod.POST, "/auth/user/**").hasRole("DEVICE")
                 it.requestMatchers(HttpMethod.POST, "/auth/device/token").permitAll()
-                // 이용
-                it.requestMatchers(HttpMethod.GET, "/item", "/space").hasRole("DEVICE")
-                it.requestMatchers(HttpMethod.POST, "/usage").hasRole("USER")
-                it.requestMatchers(HttpMethod.GET, "/form").hasRole("DEVICE")
-                it.requestMatchers(HttpMethod.POST, "/form").hasRole("USER")
-                it.requestMatchers(HttpMethod.POST, "/item").hasRole("DEVICE")
-                it.requestMatchers(HttpMethod.DELETE, "/item", "/usage").hasRole("DEVICE")
-                // 관리
-                it.requestMatchers("/admin/**").hasRole("ADMIN")
+
                 // 모니터링
                 it.requestMatchers(HttpMethod.GET, "/actuator/**").permitAll()
                 it.requestMatchers(HttpMethod.GET, "/health").permitAll()
+
+                // DEVICE
+                it.requestMatchers(HttpMethod.POST, "/auth/user/**").hasRole("DEVICE")
+                it.requestMatchers(HttpMethod.GET, "/item", "/space").hasRole("DEVICE")
+                it.requestMatchers(HttpMethod.GET, "/form").hasRole("DEVICE")
+                it.requestMatchers(HttpMethod.POST, "/item").hasRole("DEVICE")
+                it.requestMatchers(HttpMethod.DELETE, "/item", "/usage").hasRole("DEVICE")
+                it.requestMatchers("/help/**").hasRole("DEVICE")
+
+                // USER
+                it.requestMatchers(HttpMethod.POST, "/usage").hasRole("USER")
+                it.requestMatchers(HttpMethod.POST, "/form").hasRole("USER")
+
+                // ADMIN
+                it.requestMatchers("/admin/**").hasRole("ADMIN")
+
                 // 그 외
-                it.anyRequest().authenticated()
+                it.anyRequest().permitAll()
             }.build()
 
     fun corsConfig(): CorsConfigurationSource {

--- a/src/main/kotlin/org/aing/danurirest/global/security/handler/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/org/aing/danurirest/global/security/handler/CustomAuthenticationEntryPoint.kt
@@ -1,0 +1,29 @@
+package org.aing.danurirest.global.security.handler
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.aing.danurirest.global.exception.dto.CustomExceptionResponse
+import org.aing.danurirest.global.exception.enums.CustomErrorCode
+import org.springframework.http.MediaType
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+
+@Component
+class CustomAuthenticationEntryPoint(
+    private val objectMapper: ObjectMapper,
+) : AuthenticationEntryPoint {
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException,
+    ) {
+        val exceptionResponse = CustomExceptionResponse(CustomErrorCode.MISSING_TOKEN)
+        
+        response.status = exceptionResponse.status.status.value()
+        response.characterEncoding = Charsets.UTF_8.name()
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.writer.print(objectMapper.writeValueAsString(exceptionResponse))
+    }
+}

--- a/src/main/kotlin/org/aing/danurirest/global/security/handler/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/org/aing/danurirest/global/security/handler/CustomAuthenticationEntryPoint.kt
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.aing.danurirest.global.exception.dto.CustomExceptionResponse
 import org.aing.danurirest.global.exception.enums.CustomErrorCode
+import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.security.core.AuthenticationException
 import org.springframework.security.web.AuthenticationEntryPoint
@@ -20,10 +21,13 @@ class CustomAuthenticationEntryPoint(
         authException: AuthenticationException,
     ) {
         val exceptionResponse = CustomExceptionResponse(CustomErrorCode.MISSING_TOKEN)
-        
+
         response.status = exceptionResponse.status.status.value()
         response.characterEncoding = Charsets.UTF_8.name()
         response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.setHeader(HttpHeaders.WWW_AUTHENTICATE, "Bearer")
+        response.setHeader(HttpHeaders.CACHE_CONTROL, "no-store")
         response.writer.print(objectMapper.writeValueAsString(exceptionResponse))
+        response.writer.flush()
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,6 +11,12 @@ spring:
       write-dates-as-timestamps: false
     date-format: yyyy-MM-dd'T'HH:mm:ss
 
+  mvc:
+    throw-exception-if-no-handler-found: true
+  web:
+    resources:
+      add-mappings: false
+
   jpa:
     properties:
       hibernate:


### PR DESCRIPTION
## 💡 배경 및 개요

* 기존에는 토큰 없이 요청을 보낼 경우 Response Body 없이 **403 상태 코드만** 반환되어, 원인 파악이 어려웠습니다.
* 또한 실제로 엔드포인트가 존재하지 않는 경우에도 상태 코드만 내려가 문제 원인을 알기 힘들어 개선이 필요했습니다.

## 📃 작업내용

* `NoHandlerFoundException::class`에 대한 ExceptionHandler 추가 → Response Body 반환하도록 수정
* Spring Security Configuration 개선 → 존재하지 않는 엔드포인트까지 인증을 요구하던 문제 해결

## 🙋‍♂️ 리뷰노트



## ✅ PR 체크리스트

* [x] 변경에 따라 문서(`.env`, 노션, README 등)가 업데이트되었나요?
* [x] 변경 사항을 공유해야 하는 팀원들에게 전달했나요?
* [x] 코드가 정상적으로 동작하나요?
* [x] Merge 대상 브랜치가 올바른가요?
* [x] PR과 직접 관련 없는 작업은 포함되지 않았나요?

## 🎸 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 비인증 접근 시 “인증 토큰이 필요합니다.” 등 표준화된 오류 응답 제공
  - 존재하지 않는 경로 요청 시 “엔드포인트를 찾을 수 없습니다.” 오류 응답 제공
  - 상태 확인용 모니터링 엔드포인트가 인증 없이 조회 가능

- 리팩터링
  - 권한 규칙 정비: DEVICE/USER/ADMIN별 접근 범위 명확화 및 일부 경로는 기본적으로 공개
  - DEVICE 권한이 필요한 도움말, 아이템/공간 조회 등 규칙 정리
  - USER 권한이 필요한 사용 기록/양식 생성 규칙 명확화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->