### PR TITLE
기기 연결 코드 만료 시간 필드 추가

### DIFF
--- a/src/main/kotlin/org/aing/danurirest/domain/admin/dto/SignInDeviceResponse.kt
+++ b/src/main/kotlin/org/aing/danurirest/domain/admin/dto/SignInDeviceResponse.kt
@@ -1,6 +1,9 @@
 package org.aing.danurirest.domain.admin.dto
 
+import java.time.LocalDateTime
+
 data class SignInDeviceResponse(
     val qrLink: String,
     val code: String,
+    val expireAt: LocalDateTime,
 )

--- a/src/main/kotlin/org/aing/danurirest/domain/admin/usecase/SignInDeviceUsecase.kt
+++ b/src/main/kotlin/org/aing/danurirest/domain/admin/usecase/SignInDeviceUsecase.kt
@@ -11,6 +11,7 @@ import org.aing.danurirest.persistence.device.entity.VerificationCode
 import org.aing.danurirest.persistence.device.repository.DeviceJpaRepository
 import org.aing.danurirest.persistence.device.repository.VerificationCodeRepository
 import org.springframework.stereotype.Service
+import java.time.LocalDateTime
 import java.util.*
 
 @Service
@@ -56,6 +57,7 @@ class SignInDeviceUsecase(
         return SignInDeviceResponse(
             qrLink,
             verifyCode,
+            LocalDateTime.now().plusMinutes(3),
         )
     }
 }


### PR DESCRIPTION
## 💡 JIRA TICKET

[DANURI-40]

## 📃 작업내용

- 기기 연결 코드 만료 시간 필드 추가

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

[DANURI-40]: https://danuri-team.atlassian.net/browse/DANURI-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 기기 로그인 시 발급되는 QR/인증코드에 “만료 시각”이 포함되어 응답으로 제공됩니다.
  - 만료 기준은 현재 시각으로부터 3분이며, 화면/클라이언트에서 남은 시간 표시, 자동 새로고침 등 UX를 개선할 수 있습니다.
  - 사용자는 만료 전까지 코드를 사용해 인증할 수 있어 유효기간을 명확히 인지하고, 보안성과 사용 편의성이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->