### PR TITLE
가입 폼 타이틀 유저 관리 엔드포인트에 포함 해서 보내기

### DIFF
--- a/src/main/kotlin/org/aing/danurirest/domain/admin/controller/AdminUserController.kt
+++ b/src/main/kotlin/org/aing/danurirest/domain/admin/controller/AdminUserController.kt
@@ -1,6 +1,7 @@
 package org.aing.danurirest.domain.admin.controller
 
 import jakarta.validation.Valid
+import org.aing.danurirest.domain.admin.dto.GetUsersAndFormHeaderList
 import org.aing.danurirest.domain.admin.dto.UserRequest
 import org.aing.danurirest.domain.admin.dto.UserResponse
 import org.aing.danurirest.domain.admin.usecase.CreateUserUsecase
@@ -62,7 +63,7 @@ class AdminUserController(
         }
 
     @GetMapping
-    fun getCurrentCompanyUsers(): ResponseEntity<List<UserResponse>> =
+    fun getCurrentCompanyUsers(): ResponseEntity<GetUsersAndFormHeaderList> =
         getCompanyUsersUsecase.execute().run {
             ResponseEntity.ok(this)
         }

--- a/src/main/kotlin/org/aing/danurirest/domain/admin/dto/FormResponse.kt
+++ b/src/main/kotlin/org/aing/danurirest/domain/admin/dto/FormResponse.kt
@@ -1,7 +1,7 @@
 package org.aing.danurirest.domain.admin.dto
 
 import org.aing.danurirest.persistence.form.entity.Form
-import java.util.UUID
+import java.util.*
 
 data class FormResponse(
     val id: UUID,

--- a/src/main/kotlin/org/aing/danurirest/domain/admin/dto/FormSchema.kt
+++ b/src/main/kotlin/org/aing/danurirest/domain/admin/dto/FormSchema.kt
@@ -1,0 +1,14 @@
+package org.aing.danurirest.domain.admin.dto
+
+import org.aing.danurirest.domain.admin.dto.enum.FormType
+
+data class FormSchema(
+    val id: Int,
+    val key: String,
+    val type: FormType,
+    val label: String,
+    val options: List<FormSchemaOptions>,
+    val placeholder: String?,
+    val isRequired: Boolean,
+    val isMultiSelect: Boolean,
+)

--- a/src/main/kotlin/org/aing/danurirest/domain/admin/dto/FormSchemaOptions.kt
+++ b/src/main/kotlin/org/aing/danurirest/domain/admin/dto/FormSchemaOptions.kt
@@ -1,0 +1,6 @@
+package org.aing.danurirest.domain.admin.dto
+
+data class FormSchemaOptions(
+    val id: Number,
+    val option: String,
+)

--- a/src/main/kotlin/org/aing/danurirest/domain/admin/dto/GetUsersAndFormHeaderList.kt
+++ b/src/main/kotlin/org/aing/danurirest/domain/admin/dto/GetUsersAndFormHeaderList.kt
@@ -1,0 +1,6 @@
+package org.aing.danurirest.domain.admin.dto
+
+data class GetUsersAndFormHeaderList(
+    val userList: List<UserResponse>,
+    val headerList: List<String>,
+)

--- a/src/main/kotlin/org/aing/danurirest/domain/admin/dto/enum/FormType.kt
+++ b/src/main/kotlin/org/aing/danurirest/domain/admin/dto/enum/FormType.kt
@@ -1,0 +1,6 @@
+package org.aing.danurirest.domain.admin.dto.enum
+
+enum class FormType {
+    SELECT,
+    INPUT,
+}

--- a/src/main/kotlin/org/aing/danurirest/domain/admin/usecase/CreateFormUsecase.kt
+++ b/src/main/kotlin/org/aing/danurirest/domain/admin/usecase/CreateFormUsecase.kt
@@ -36,6 +36,8 @@ class CreateFormUsecase(
             )
 
         val savedForm = formJpaRepository.save(form)
-        return FormResponse.from(savedForm)
+        return FormResponse.from(
+            savedForm,
+        )
     }
 }

--- a/src/main/kotlin/org/aing/danurirest/domain/admin/usecase/GetUsersUsecase.kt
+++ b/src/main/kotlin/org/aing/danurirest/domain/admin/usecase/GetUsersUsecase.kt
@@ -1,7 +1,15 @@
 package org.aing.danurirest.domain.admin.usecase
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.aing.danurirest.domain.admin.dto.FormSchema
+import org.aing.danurirest.domain.admin.dto.GetUsersAndFormHeaderList
 import org.aing.danurirest.domain.admin.dto.UserResponse
 import org.aing.danurirest.domain.auth.admin.usecase.GetAdminCompanyIdUsecase
+import org.aing.danurirest.global.exception.CustomException
+import org.aing.danurirest.global.exception.enums.CustomErrorCode
+import org.aing.danurirest.persistence.form.entity.QForm.Companion.form
+import org.aing.danurirest.persistence.form.repository.FormJpaRepository
 import org.aing.danurirest.persistence.user.repository.UserJpaRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -9,12 +17,29 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class GetUsersUsecase(
     private val userJpaRepository: UserJpaRepository,
+    private val formJpaRepository: FormJpaRepository,
     private val getAdminCompanyIdUsecase: GetAdminCompanyIdUsecase,
+    private val objectMapper: ObjectMapper,
 ) {
     @Transactional(readOnly = true)
-    fun execute(): List<UserResponse> {
+    fun execute(): GetUsersAndFormHeaderList {
         val companyId = getAdminCompanyIdUsecase.execute()
         val users = userJpaRepository.findAllByCompanyId(companyId)
-        return users.map { UserResponse.from(it) }
+
+        val form =
+            formJpaRepository
+                .findByCompanyIdAndSignUpFormTrue(
+                    companyId,
+                ).orElseThrow { CustomException(CustomErrorCode.FORM_IS_NOT_SETUP) }
+
+        val json: List<FormSchema> = objectMapper.readValue<List<FormSchema>>(form.formSchema)
+
+        val headerList: MutableList<String> = mutableListOf()
+
+        json.forEach { schema ->
+            headerList.add(schema.label)
+        }
+
+        return GetUsersAndFormHeaderList(users.map { UserResponse.from(it) }, headerList)
     }
 }


### PR DESCRIPTION
## 💡 JIRA TICKET

[DANURI-39]

## 📃 작업내용

- 가입 폼 템플릿에서, String -> JSON으로 변환 하여 인식하고 `title` 필드를 모두 포함한 리스트를 유저 정보와 함께 리턴합니다.

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?